### PR TITLE
Apt key full fingerprint.

### DIFF
--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -21,12 +21,12 @@ class docker_registry::repos {
       }  
 
       apt::source { 'docker':
-        location   => 'https://get.docker.com/ubuntu',
+        location    => 'https://get.docker.com/ubuntu',
         include_src => false,
-        repos      => 'docker main',
-        release => '',
-        key               => 'A88D21E9',
-        key_server        => 'keyserver.ubuntu.com',
+        repos       => 'docker main',
+        release     => '',
+        key         => '36A1D7869245C8950F966E92D8576A8BA88D21E9',
+        key_server  => 'keyserver.ubuntu.com',
      }
 
      file { '/sbin/insserv' : 


### PR DESCRIPTION
In order to avoid the message below, I suggest to upgrade the apt key.

```
Warning: /Apt_key[Add key: A88D21E9 from Apt::Source docker]: The id should be a full fingerprint (40 characters), see README.
```
