### PR TITLE
Puppet-apt instantiation is simplified.

### DIFF
--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -2,22 +2,8 @@ class docker_registry::repos {
 
   case $::osfamily {
     debian: {
-      class { 'apt':
-        always_apt_update    => true,
-        apt_update_frequency => undef,
-        disable_keys         => undef,
-        proxy_host           => false,
-        proxy_port           => false,
-        purge_sources_list   => false,
-        purge_sources_list_d => false,
-        purge_preferences_d  => false,
-        update_timeout       => undef,
-        fancy_progress       => true
-      }
-
-
-      class { 'apt::release':
-        release_id => '',
+      if !defined(Class['apt']) {
+        class { 'apt': }
       }  
 
       apt::source { 'docker':


### PR DESCRIPTION
Apt arguments are no more the good ones. I suggest to simplify the instantiation and take into account that the class can be already defined.
